### PR TITLE
Update webpack config to reduce scope of /ChartIQ/ exclusion to project subfolders

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ module.exports = {
 						{
 								test: /\.(js|jsx)$/,
 								exclude: [
-										/node_modules/, /ChartIQ/
+									/node_modules/, 
+									path.resolve(__dirname, 'chartiq')
 								],
 								use: ['babel-loader']
 						}


### PR DESCRIPTION
/ChartIQ/ exclusion in webpack config prevents working on projects with path containing pattern ChartIQ. 

For example projects with path:
C:/projects/ChartIQ/
/Users/xyz/development/ChartIQProjects/
would fail to compile as jsx would not be transpiled by babel-loader

Addition of the path.resolve(__dirname, 'chartiq') reduces scope to folders inside the project structure.